### PR TITLE
Give more freedom to the user to choose lock grace period

### DIFF
--- a/settings/kscreenlockersettings.kcfg
+++ b/settings/kscreenlockersettings.kcfg
@@ -24,7 +24,7 @@
     <entry key="LockGrace" type="Int">
       <default>5</default>
       <min>0</min>
-      <max>300</max>
+      <max>3600</max>
       <label></label>
       <whatsthis></whatsthis>
     </entry>


### PR DESCRIPTION
300 seconds was too restrictive. A 0-3600 second interval gives more freedom to the user to configure their screen locking experience.